### PR TITLE
fix: update feed/sitemap links to be absolute

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -51,8 +51,8 @@
         <div class="mb-8 lg:mb-0">
           <div>Copyright 2019. All rights reserved.</div>
           <div>
-            <a href="rss.xml" class="text-white hover:text-gray-400 font-normal">RSS Feed</a> |
-            <a href="sitemap.xml" class="text-white hover:text-gray-400 font-normal">Sitemap</a>
+            <a href="/rss.xml" class="text-white hover:text-gray-400 font-normal">RSS Feed</a> |
+            <a href="/sitemap.xml" class="text-white hover:text-gray-400 font-normal">Sitemap</a>
           </div>
         </div>
         <ul class="flex items-center">


### PR DESCRIPTION
Currently they are relative, so if you are on a docs post for example and try to visit one of them you'll end up with a 404.

Example page with issue:
https://gridsome-portfolio-starter.netlify.com/docs/vue-components-in-markdown/