### PR TITLE
Add alt text to the 404 image for accessibility

### DIFF
--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -2,7 +2,7 @@
   <Layout>
     <div class="container-inner mx-auto py-16">
       <h2 class="text-4xl font-bold mb-16">Page Not Found</h2>
-      <g-image src="../../static/404.svg" />
+      <g-image src="../../static/404.svg" alt="404 page not foud"/>
     </div>
 
   </Layout>


### PR DESCRIPTION
For accessibility `alt` text is required on images elements.

This also has the benefit of increasing the lighthouse accessibility score out of the box.