### PR TITLE
add search data to component and add doc pages (closes #84)

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -5,71 +5,7 @@
 // Changes here require a server restart.
 // To restart press CTRL + C in terminal and run `gridsome develop`
 
-const fs = require('fs');
-const path = require('path');
-const pick = require('lodash.pick');
-const { pathPrefix } = require('./gridsome.config')
-
 module.exports = function (api, options) {
   api.loadSource(store => {
-    /*
-    Clean the pathPrefix
-    ====================
-    not used =>  '/'
-    ''       =>  '/'
-    '/'      =>  '/'
-    '/path'  =>  '/path'
-    'path'   =>  '/path'
-    'path/'  =>  '/path'
-    '/path/' =>  '/path'
-    */
-    const cleanedPathPrefix = `${pathPrefix ? ['', ...pathPrefix.split('/').filter(dir=>dir.length)].join('/') : ''}`
-
-    /*
-    Query
-    =====
-    <static-query>        <!-- or a page-query -->
-    {
-      metaData{
-        pathPrefix
-      }
-    }
-    </static-query>
-
-    Requests for static files should look like this:
-    ===============================================
-    Using static-queries: axios( this.$static.metaData.pathPrefix + "/fileName" )
-    Using page-queries,   axios( this.$page.metaData.pathPrefix   + "/fileName" )
-    */
-    store.addMetadata('pathPrefix', cleanedPathPrefix)
-  })
-
-  api.beforeBuild(({ config, store }) => {
-
-    // Generate an index file for Fuse to search Posts
-    const { collection } = store.getContentType('Post');
-
-    const posts = collection.data.map(post => {
-      return pick(post, ['title', 'path', 'summary']);
-    });
-
-    const output = {
-      dir: './static',
-      name: 'search.json',
-      ...options.output
-    }
-
-    const outputPath = path.resolve(process.cwd(), output.dir)
-    const outputPathExists = fs.existsSync(outputPath)
-    const fileName = output.name.endsWith('.json')
-      ? output.name
-      : `${output.name}.json`
-
-    if (outputPathExists) {
-      fs.writeFileSync(path.resolve(process.cwd(), output.dir, fileName), JSON.stringify(posts))
-    } else {
-      fs.mkdirSync(outputPath)
-      fs.writeFileSync(path.resolve(process.cwd(), output.dir, fileName), JSON.stringify(posts))
-    }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9555,11 +9555,6 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-    },
     "lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gridsome": "^0.7.14",
     "gridsome-plugin-remark-shiki": "^0.3.1",
     "gridsome-plugin-rss": "^1.2.0",
-    "lodash.pick": "^4.4.0",
     "vue-fuse": "^2.2.1",
     "vue-scrollto": "^2.18.1"
   },

--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -57,34 +57,66 @@
 
 
 <static-query>
-  {
-    metadata{
-      pathPrefix
+query Search {
+  allPost {
+    edges {
+      node {
+        id
+        path
+        title
+        summary
+        headings {
+          depth
+          value
+          anchor
+        }
+      }
     }
   }
+  allDocumentation {
+    edges {
+      node {
+        id
+        path
+        title
+      }
+    }
+  }
+}
 </static-query>
 
 <script>
-import axios from 'axios'
 import SearchFocus from './SearchFocus'
 
 export default {
   components: {
     SearchFocus,
   },
-  created() {
-    axios(this.$static.metadata.pathPrefix + "/search.json").then(response => {
-      this.posts = response.data
-    })
-    .catch(error => {
-      console.log(error);
-    })
+  computed: {
+    pages () {
+      let result = [];
+      const allPost = this.$static.allPost.edges.map(edge => edge.node);
+      allPost.forEach(page => {
+        result.push({
+          path: page.path,
+          title: page.title,
+          summary: page.summary
+        });
+      });
+      const allDocs = this.$static.allDocumentation.edges.map(edge => edge.node);
+      allDocs.forEach(page => {
+        result.push({
+          path: page.path,
+          title: page.title
+        });
+      });
+      return result;
+    }
   },
   data() {
     return {
       query: '',
       results: [],
-      posts: [],
       highlightedIndex: 0,
       searchResultsVisible: false,
       options: {
@@ -109,7 +141,7 @@ export default {
       this.searchResultsVisible = true
     },
     performSearch() {
-      this.$search(this.query, this.posts, this.options).then(results => {
+      this.$search(this.query, this.pages, this.options).then(results => {
         this.results = results
       })
     },


### PR DESCRIPTION
Thanks for the nice starter! Here is an attempt at adding the doc pages to the search (#84). You should be more easily able to add any other nodes too since it is all done inside the component now.

* Moves search data to the component as a static query
* Adds doc pages to search query data

Used [this repo](https://github.com/mrcrmn/docc/blob/135adfc1fa771bb6ccb6c3c1a1273c224c789467/src/components/Search.vue) as an example. You could also add in headings (though need to change the UI).